### PR TITLE
Add new default visibility option 'any'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Name                            | Description
 `showJobNames`                  | Show job names instead of status icons. Default: `false`
 `showDurations`                 | Show pipeline durations. Default: `true`
 `showUsers`                     | Show user that invoked a pipeline. Default: `false`
-`projectVisibility`             | Limit projects by visibility. Default: `internal`, Can be: `public`, `internal` or `private`
+`projectVisibility`             | Limit projects by visibility. Default: `any`, Can be: `any`, `public`, `internal` or `private`
 
 ## Minimal example:
 

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -52,11 +52,18 @@
     },
     methods: {
       async fetchProjects() {
-        const projects = await this.$api('/projects', {
+        const gitlabApiParams = {
           order_by: 'last_activity_at',
-          visibility: getQueryParameter('projectVisibility') || 'internal',
           per_page: getQueryParameter('fetchCount') || 20
-        });
+        };
+        const visibility = getQueryParameter('projectVisibility') || 'any';
+        // Only add the visibility attribute to the params if filtering is required
+        // (if visiblity is not specified, Gitlab will return all projects)
+        if (visibility !== 'any') {
+          gitlabApiParams.visibility = visibility;
+        }
+
+        const projects = await this.$api('/projects', gitlabApiParams);
 
         // Only show projects that have jobs enabled
         const maxAge = (getQueryParameter('maxAge') !== null ? getQueryParameter('maxAge') : 24 * 7);


### PR DESCRIPTION
Currently there is no way to show all projects in the monitor regardless of visibility. So this PR adds an 'any' option that results in no visibility filter being given to the Gitlab API. It also becomes the default, as, thinking about it logically, if a filter is not provided, then no filter should be applied.