### PR TITLE
Add support for following next page links when fetching projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Name                            | Description
 `gitlabApi` (required)          | URL to your GitLab API. (e.g. `https://gitlab.example.com/api/v4`)
 `privateToken` (required)       | Private token to access the GitLab API
 `maxAge`                        | In hours. Projects with last activity older than this age won't be displayed. Default: 7 days
-`fetchCount`                    | How many projects will be fetched from GitLab. Default: 20, Max: 100
+`fetchCount`                    | How many projects will be fetched from GitLab. If set to greater than 100, then all available projects will be retrieved (in batches of 100). Default: 20
 `pipelinesOnly`                 | Show only projects with recent pipelines. Default: `false`
 `autoZoom`                      | Zooms the dashboard to fill the screen with all displayed projects. [Not compatible](https://caniuse.com/#feat=css-zoom) with all browsers! Default: `false`
 `showPipelineIds`               | Don't show pipeline IDs. Default: `true`

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^0.17.1",
+    "parse-link-header":"^1.0.1",
     "vue": "^2.5.11",
     "vue-octicon": "^2.1.1",
     "vue-timeago": "^3.4.2"

--- a/src/GitLabApi.js
+++ b/src/GitLabApi.js
@@ -1,15 +1,28 @@
 import axios from 'axios';
+import parse from 'parse-link-header'
 
 const GitLabApi = {};
 
 GitLabApi.install = (Vue, options) => {
-  Vue.prototype.$api = async (path, params = {}) => {
+  Vue.prototype.$api = async (path, params = {}, behaviour = {}) => {
     const response = await axios.get(path, {
       baseURL: options.gitlab_api_url,
       params,
       headers: {'Private-Token': options.private_token}
     });
-    return response.data;
+    const result = response.data;
+    if (behaviour.follow_next_page_links) {
+      // Find the "next" link header and follow it, until we get a result that has no next link
+      let parsedLinks = parse(response.headers.link);
+      while (parsedLinks && parsedLinks.next) {
+        const nextResponse = await axios.get(parsedLinks.next.url, {
+          headers: {'Private-Token': options.private_token}
+        });
+        result.push(...nextResponse.data);
+        parsedLinks = parse(nextResponse.headers.link);
+      }
+    }
+    return result;
   };
 };
 

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -52,10 +52,13 @@
     },
     methods: {
       async fetchProjects() {
+        const fetchCount = getQueryParameter('fetchCount') || 20;
         const gitlabApiParams = {
           order_by: 'last_activity_at',
-          per_page: getQueryParameter('fetchCount') || 20
+          // GitLab per_page max is 100. We use > 100 values as next page follow trigger
+          per_page: fetchCount > 100 ? 100 : fetchCount
         };
+
         const visibility = getQueryParameter('projectVisibility') || 'any';
         // Only add the visibility attribute to the params if filtering is required
         // (if visiblity is not specified, Gitlab will return all projects)
@@ -63,7 +66,7 @@
           gitlabApiParams.visibility = visibility;
         }
 
-        const projects = await this.$api('/projects', gitlabApiParams);
+        const projects = await this.$api('/projects', gitlabApiParams, {follow_next_page_links: fetchCount > 100});
 
         // Only show projects that have jobs enabled
         const maxAge = (getQueryParameter('maxAge') !== null ? getQueryParameter('maxAge') : 24 * 7);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,6 +3756,12 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-link-header@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-1.0.1.tgz#bedfe0d2118aeb84be75e7b025419ec8a61140a7"
+  dependencies:
+    xtend "~4.0.1"
+
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
@@ -5544,7 +5550,7 @@ xml-char-classes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
 
-xtend@^4.0.0:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
For teams with a lot of projects, they can be split over multiple pages even if fetchCount is 100. So this PR adds the ability to follow the chain of next page links that the GitLab API provides, in order to build up a true list of projects. It is set to happen by default but a new followNextPageLinks query parameter is provided that enables a return to the old behaviour by setting it to false.

I made it a call-by-call option (via a new "behaviour" method parameter into $api) so the other internal API calls can make their own choice as to whether they care about a full list.