### PR TITLE
Add project path prefix filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,11 @@ Name                            | Description
 `showDurations`                 | Show pipeline durations. Default: `true`
 `showUsers`                     | Show user that invoked a pipeline. Default: `false`
 `projectVisibility`             | Limit projects by visibility. Default: `any`, Can be: `any`, `public`, `internal` or `private`
-`groups`                        | List of project groups that are included. Multiple groups can be provided comma-separated or in multiple `groups` values. Note that `groups` and `projects` are combined together if both are provided.
-`projects`                      | List of projects that are included. Multiple projects can be provided comma-separated or in multiple `projects` values. Note that `groups` and `projects` are combined together if both are provided.
+`groups`                        | List of project groups that are included. Multiple groups can be provided comma-separated or in multiple `groups` values.
+`projects`                      | List of projects that are included. Multiple projects can be provided comma-separated or in multiple `projects` values.
+`paths`                         | List of project paths that are included. Multiple paths can be provided comma-separated or in multiple `paths` values.
+
+Note that `groups`, `projects` and `paths` are combined together if more then one are provided.
 
 ## Minimal example
 

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -83,11 +83,17 @@
           includeProjects = includeProjects.split(',');
         }
 
+        let includePaths = (getQueryParameter('paths') !== null ? getQueryParameter('paths') : '');
+        if (typeof includePaths === 'string') {
+          includePaths = includePaths.split(',');
+        }
+
         this.$data.projects = projects.filter((project) => {
           return project.jobs_enabled &&
             (maxAge === 0 || ((new Date() - new Date(project.last_activity_at)) / 1000 / 60 / 60 <= maxAge)) &&
             (
-              (includeGroups[0] === '' && includeProjects[0] === '') ||
+              (includeGroups[0] === '' && includeProjects[0] === '' && includePaths[0] === '') ||
+              (includePaths.some((path) => project.path_with_namespace.startsWith(path))) ||
               (includeGroups.some((group) => group === project.namespace.name)) ||
               (includeProjects.some((group) => group === project.name_with_namespace))
             );


### PR DESCRIPTION
Add a new parameter to filter projects which have specific path prefix.

For example: `http://localhost:8080/?paths=foo/bar/` will list all projects under `foo` group and `bar` sub-group.