### PR TITLE
Use Docker multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+.git
+.gitignore
+.gitlab-ci.yml
+.editorconfig
+.markdownlint.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-FROM node:alpine
-ADD . /
+#Stage 1
+FROM node:10.8-alpine as yarnbuild
+
+WORKDIR /usr/src/app
+COPY . ./
 RUN yarn install
 RUN yarn build
-EXPOSE 8080
-CMD yarn run serve
+
+# Stage 2
+FROM nginx:1.14-alpine
+COPY --from=yarnbuild /usr/src/app/dist /usr/share/nginx/html
+EXPOSE 80


### PR DESCRIPTION
I've found your project pretty cool and I wanted to contribute to it.

I know my ways with Docker and therefore I'm proposing small optimisations.

What I've done is transform the Dockerfile into a multistage build. Meaning the first stage is only there to build the application and is "discarded" (1), the second stage picks up just the build data, nothing else.

The total build time is about the same, but the multistage approach provides the following advantages:

* Final image (the "production image") **size** is **reduced from 280MB to 20MB** (both uncompressed)
* Container **startup** time went **down from about 14s to 1s** (on my underpower laptop with a SSD)
* Container resource usage has been improved:
  * **RAM** usage went **down from 55MB to 2MB**
  * **IO** usage for startup went **down from 33.6MB to 3.9MB**

Measurements done on Fedora 28, using btrfs storage backend for Docker CE 18.06.0, on a laptop with a SSD and dual core mobile CPU.

By using this multistage build, it should not be necessary to package `http-server`, unless you see other uses outside of Docker. In my first PR I had removed it but I decided to let it and its up to you to see if it is still necessary (e.g. other use cases outside of Docker).

Finally, I have added what's called a `.dockerignore` file which will help avoiding copying unnecessary data to the 1st stage, and therefore Docker will not do a full rebuild and drop its cached if one of these data has change.

*(1): The first stage is not really discarded, it is still cached by Docker so it can still accelerate subsequent builds, but only a subset of the data from 1st stage will be use in 2nd stage.*