### PR TITLE
Add option to search projects from under a specific user or group

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -122,7 +122,15 @@ Your configuration overrides the default configuration, which can be found
     "my-project/my-group": {
       // see above...
     }
-  }
+  },
+
+  // Search projects from given API route.
+  // Allowed values "groups" and "users"
+  "projectScope": null,
+  
+  // ID to use in query with "projectScope" parameter
+  // For example 123 with "projectScope": "groups" would query /groups/123/projects
+  "projectScopeId": null
 }
 ```
 

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -93,7 +93,15 @@
           gitlabApiParams.membership = membership
         }
 
-        const projects = await this.$api('/projects', gitlabApiParams, { follow_next_page_links: fetchCount > 100 })
+        // Only use main level projects API if tighter scope not defined
+        const scope = Config.root.projectScope
+        const scopeId = Config.root.projectScopeId
+        let urlPrefix = ''
+        if ((scope === 'users' || scope === 'groups') && scopeId !== null) {
+          urlPrefix = '/' + scope + '/' + scopeId
+        }
+
+        const projects = await this.$api(urlPrefix + '/projects', gitlabApiParams, { follow_next_page_links: fetchCount > 100 })
 
         // Only show projects that have jobs enabled
         const maxAge = Config.root.maxAge

--- a/src/config.default.json
+++ b/src/config.default.json
@@ -31,5 +31,7 @@
       "maxPipelines": 0,
       "hideSkippedPipelines":  false
     }
-  }
+  },
+  "projectScope": null,
+  "projectScopeId": null
 }


### PR DESCRIPTION
With larger Gitlab instances, searching projects from the whole Gitlab with API route `/projects` and filtering them from the response gets quite slow. I would be interested to monitor projects under a specific user or group. In this scenario the loading time could be reduced by using `groups/:id/projects` or `users/:id/projects` API routes.

This PR would add an option to use the above mentioned APIs, by using config parameters `projectScope` and `projectScopeId`, which default to `null`.