### PR TITLE
Support fetching projects from all subgroups from given group

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -17,6 +17,10 @@ privateToken: ABCDEF123456
 # If set to 0, no filter will be applied
 maxAge: 168
 
+#How many projects will be fetched from GitLab. Usually you want all projects under a user/group.
+#If set to greater than 100, then all available projects will be retrieved (in batches of 100)
+fetchCountProjects: 101,
+
 # How many projects will be fetched from GitLab.
 # If set to greater than 100, then all available projects will be retrieved (in batches of 100)
 fetchCount: 20
@@ -161,6 +165,10 @@ projectScope: null
 # For example 123 with "projectScope": "groups" would query /groups/123/projects
 # Specify an array if you with to include multiple scope IDs.
 projectScopeId: null
+
+# If projectScope is "groups" you might be interested in using includeSubgroups to include
+# projects from all subgroups within the group specified in projectScopeId.
+includeSubgroups:  false
 ```
 
 ## Headless configuration

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -99,7 +99,7 @@
     },
     methods: {
       async fetchProjects() {
-        const fetchCount = Config.root.fetchCount
+        const fetchCount = Config.root.fetchCountProjects
         const gitlabApiParams = {
           order_by: 'last_activity_at',
           // GitLab per_page max is 100. We use > 100 values as next page follow trigger
@@ -117,6 +117,10 @@
         const membership = Config.root.membership
         if (typeof membership === 'boolean') {
           gitlabApiParams.membership = membership
+        }
+        const includeSubgroups = Config.root.includeSubgroups
+        if (typeof includeSubgroups === 'boolean') {
+          gitlabApiParams.include_subgroups = includeSubgroups
         }
 
         // Only use main level projects API if tighter scope not defined


### PR DESCRIPTION
Instead of only fetching projects under group foo, also include projects
from all subgroups that exists under group foo.

ie with the following projects:

```
├── foo (group)
│    ├── bar (group)
│    │   ├─── baz (project)
│    │   ├─── taz (project)
│    │ 
│    ├── zar (project)
```
With projectScopeId foo and include_subgroups set to true, it will now
also include the project baz and taz.  If false it would only include
zar.

Introducing own fetchCountProjects as you usually is always in crawling
all projects.

Highly recommended to be used together with https://github.com/timoschwarzer/gitlab-monitor/pull/74
