### PR TITLE
Add an option to display pipeline stages names

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -48,6 +48,9 @@ Your configuration overrides the default configuration, which can be found
     "manual"
   ],
 
+  // Whether to show stages names
+  "showStagesNames": false,
+
   // Whether to show pipeline durations or not
   "showDurations": true,
   

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -14,7 +14,7 @@
         {{ pipeline.ref }}
       </a>
 
-      <div :class="'pipeline' + (showStagesNames ? ' with-stages-names' : '')">
+      <div :class="['pipeline', {'with-stages-names': showStagesNames}]">
         <a
           class="pipeline-id-link"
           target="_blank"

--- a/src/components/stage-view.vue
+++ b/src/components/stage-view.vue
@@ -1,0 +1,91 @@
+<template>
+  <div :class="'stage-view' + (showStagesNames ? ' with-name' : '')">
+    <div class="jobs-queue">
+      <div class="pipe before"></div>
+      <div class="jobs">
+        <job-view v-for="job in stage.jobs" :key="job.id" :job="job" :project="project" />
+      </div>
+      <div class="pipe after"></div>
+    </div>
+    <div class="stage-title">{{ stage.name }}</div>
+  </div>
+</template>
+
+<script>
+  import Config from '../Config'
+  import JobView from './job-view'
+
+  export default {
+    components: {
+      JobView
+    },
+    name: 'stage-view',
+    props: ['stage', 'project'],
+    computed: {
+      showStagesNames() {
+        return Config.root.showStagesNames;
+      }
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  .stage-view {
+    display: inline-block;
+    color: rgba(255, 255, 255, 0.8);
+
+    &:not(.with-name) {
+      .pipe.before {
+        display: none;
+      }
+      .pipe.after {
+        min-width: auto;
+      }
+      .stage-title {
+        display: none;
+      }
+      padding-bottom: 0;
+    }
+
+    &:first-child {
+      .pipe.before {
+        display: none;
+      }
+      .stage-title {
+        padding-left: 0;
+        text-align: left;
+      }
+    }
+
+    &:last-child {
+      .pipe.after {
+        display: none;
+      }
+      .stage-title {
+        padding-right: 0;
+        text-align: right;
+      }
+    }
+
+    .stage-title {
+      padding: 3px 9px 3px 9px;
+      line-height: 12px;
+      box-sizing: border-box;
+      font-size: 12px;
+      text-align: center;
+    }
+
+    .jobs-queue {
+      display: flex;
+      align-items: center;
+    }
+
+    .pipe {
+      height: 2px;
+      background-color: rgba(255, 255, 255, 0.8);
+      width: 6px;
+      flex-grow: 1;
+      min-width: 18px;
+    }
+  }
+</style>

--- a/src/components/stage-view.vue
+++ b/src/components/stage-view.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="'stage-view' + (showStagesNames ? ' with-name' : '')">
+  <div :class="['stage-view', {'with-name': showStagesNames}]">
     <div class="jobs-queue">
       <div class="pipe before"></div>
       <div class="jobs">

--- a/src/config.default.json
+++ b/src/config.default.json
@@ -8,6 +8,7 @@
   "showPipelineIds": true,
   "showJobs": "icon",
   "showJobsNameOnlyOn": [],
+  "showStagesNames": false,
   "showDurations": true,
   "showUsers": false,
   "projectVisibility": "any",


### PR DESCRIPTION
When pipeline consists of many jobs, it appears in dashboard as very long chain and is hard to be read.
![image](https://user-images.githubusercontent.com/8066413/63213984-6b4d0c00-c11b-11e9-8ac9-698d46dc5785.png)
Jobs names does not solve this problem because pipeline becomes too long and doesn't fit the screen. As soon as Gitlab CI pipeline consists of successive stages, it would be nice to have an option to split pipeline into stages in dashboard as well, so pipeline becomes more structured visually.

This request adds an option to expand dashes between stages and display stages names using config parameter `showStagesNames`. The default is `false`, which means no unexpected changes for users.

![image](https://user-images.githubusercontent.com/8066413/63213995-933c6f80-c11b-11e9-9475-b840ec19d70a.png)