### PR TITLE
Add an option to hide restarted jobs

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -48,6 +48,9 @@ Your configuration overrides the default configuration, which can be found
     "manual"
   ],
 
+  // Whether to show jobs that was restarted
+  "showRestartedJobs": true,
+
   // Whether to show stages names
   "showStagesNames": false,
 

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -147,11 +147,11 @@
         }
 
         // Skip filtering and sorting if there is no restarted jobs
-        if (this.jobs.length == jobs_order.length) {
+        if (this.jobs.length === jobs_order.length) {
           return;
         }
 
-        this.jobs = this.jobs.filter(job => jobs_id_by_name[job["name"]] == job["id"]);
+        this.jobs = this.jobs.filter(job => jobs_id_by_name[job["name"]] === job["id"]);
         this.jobs = this.jobs.sort((j1, j2) => (jobs_order.indexOf(j1["name"]) - jobs_order.indexOf(j2["name"])));
       },
       setupDurationCounter() {

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -115,6 +115,9 @@
     methods: {
       async fetchJobs() {
         this.jobs = await this.$api(`/projects/${this.project.id}/pipelines/${this.pipeline.id}/jobs?per_page=50`)
+        if (!Config.root.showRestartedJobs) {
+          this.excludeRestartedJobs();
+        }
         this.stages = this.jobs.reduce(function(stages, job) {
           const stage_name = job["stage"]
           var stage_id = stages.findIndex(s => s["name"] === stage_name)
@@ -126,6 +129,30 @@
           return stages
         }, [])
         this.loading = false
+      },
+      excludeRestartedJobs() {
+        // Job restarts appear at the end of the list and break pipeline view.
+        // We sort jobs to place restarts on the positions of the restarted ones.
+        // This array contains list of jobs names as they was originally enqueued.
+        var jobs_order = [];
+
+        // This dictionary contains id of the latest job for each job name
+        var jobs_id_by_name = {};
+
+        for (let job of this.jobs) {
+          jobs_id_by_name[job["name"]] = job["id"];
+          if (!~jobs_order.indexOf(job["name"])) {
+            jobs_order.push(job["name"]);
+          }
+        }
+
+        // Skip filtering and sorting if there is no restarted jobs
+        if (this.jobs.length == jobs_order.length) {
+          return;
+        }
+
+        this.jobs = this.jobs.filter(job => jobs_id_by_name[job["name"]] == job["id"]);
+        this.jobs = this.jobs.sort((j1, j2) => (jobs_order.indexOf(j1["name"]) - jobs_order.indexOf(j2["name"])));
       },
       setupDurationCounter() {
         const pipeline = this.pipeline

--- a/src/config.default.json
+++ b/src/config.default.json
@@ -8,6 +8,7 @@
   "showPipelineIds": true,
   "showJobs": "icon",
   "showJobsNameOnlyOn": [],
+  "showRestartedJobs": true,
   "showStagesNames": false,
   "showDurations": true,
   "showUsers": false,


### PR DESCRIPTION
This request adds an option to hide restarted jobs using config parameter `showRestartedJobs`. The default value is `true` and restarted jobs are visible. This implies no unexpected changes for users.

Examples:
- `showRestartedJobs: true`
![изображение](https://user-images.githubusercontent.com/8066413/63259839-298da400-c288-11e9-903a-3dec10ba3f61.png)
- `showRestartedJobs: false`
![изображение](https://user-images.githubusercontent.com/8066413/63259890-47f39f80-c288-11e9-905e-a33b444f4843.png)

Closes issue #85.