### PR TITLE
Fix jobs names alignment

### DIFF
--- a/src/components/job-view.vue
+++ b/src/components/job-view.vue
@@ -91,7 +91,7 @@
       border: 2px solid rgba(255, 255, 255, 0.8);
       border-radius: 24px;
       line-height: 24px;
-      padding: 0 6px;
+      padding: 0 9px 0 0;
       font-size: 12px;
       transition: background-color 200ms;
 


### PR DESCRIPTION
Currently jobs names are misaligned slightly. The left padding of a bubble is too big and the right one is too small.

This request changes mentioned above paddings:
- Before:
![image](https://user-images.githubusercontent.com/8066413/63301987-a6e70200-c2e4-11e9-8302-c0f02e3d878d.png)
- After:
![image](https://user-images.githubusercontent.com/8066413/63301991-a9495c00-c2e4-11e9-85af-73047c254d59.png)