### PR TITLE
Allow to specify a list in projectScopeId

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -148,6 +148,7 @@ Your configuration overrides the default configuration, which can be found
   
   // ID to use in query with "projectScope" parameter
   // For example 123 with "projectScope": "groups" would query /groups/123/projects
+  // Cloud also be a list : [123, 4762, 8726]
   "projectScopeId": null
 }
 ```

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -98,7 +98,7 @@
         // Reformat the variable as a flat list of Ids
         const scopeId = [Config.root.projectScopeId].flat()
 
-        var apiPromises = []
+        const apiPromises = []
         for (let scope of scopeId) {
           let urlPrefix = ''
           if ((scopeType === 'users' || scopeType === 'groups') && scope !== null) {

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -94,14 +94,25 @@
         }
 
         // Only use main level projects API if tighter scope not defined
-        const scope = Config.root.projectScope
-        const scopeId = Config.root.projectScopeId
-        let urlPrefix = ''
-        if ((scope === 'users' || scope === 'groups') && scopeId !== null) {
-          urlPrefix = '/' + scope + '/' + scopeId
+        const scopeType = Config.root.projectScope
+        var scopeId = Config.root.projectScopeId
+
+        if (typeof scopeId === "string") {
+          scopeId = [scopeId]
+        }
+        console.log(scopeId)
+
+        var apiPromises = []
+        for (let scope of scopeId) {
+          let urlPrefix = ''
+          if ((scopeType === 'users' || scopeType === 'groups') && scope !== null) {
+            urlPrefix = '/' + scopeType + '/' + scope
+          }
+
+          apiPromises.push(this.$api(urlPrefix + '/projects', gitlabApiParams, { follow_next_page_links: fetchCount > 100 }))
         }
 
-        const projects = await this.$api(urlPrefix + '/projects', gitlabApiParams, { follow_next_page_links: fetchCount > 100 })
+        const projects = (await Promise.all(apiPromises)).flat()
 
         // Only show projects that have jobs enabled
         const maxAge = Config.root.maxAge

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -95,12 +95,8 @@
 
         // Only use main level projects API if tighter scope not defined
         const scopeType = Config.root.projectScope
-        var scopeId = Config.root.projectScopeId
-
-        if (typeof scopeId === "string") {
-          scopeId = [scopeId]
-        }
-        console.log(scopeId)
+        // Reformat the variable as a flat list of Ids
+        const scopeId = [Config.root.projectScopeId].flat()
 
         var apiPromises = []
         for (let scope of scopeId) {


### PR DESCRIPTION
This PR add support for passing an Array in the parameter `projectScopeId`.
It handle default behavior with single value or with a list

Fix #96 