### PR TITLE
[helm/chart] Don't add 'nodePort' if the service is not 'LoadBalancer'

### DIFF
--- a/charts/gitlab-monitor/Chart.yaml
+++ b/charts/gitlab-monitor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: gitlab-monitor
-version: v0.1.0
+version: v0.1.1

--- a/charts/gitlab-monitor/templates/service.yaml
+++ b/charts/gitlab-monitor/templates/service.yaml
@@ -9,7 +9,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+{{- if eq .Values.service.type "LoadBalancer"}}
     nodePort: {{ .Values.service.nodePort }}
+{{- end}}
     protocol: TCP
     name: {{ .Values.service.name }}
   selector:


### PR DESCRIPTION
If the user specify service that the type is `ClusterIP`, the service definition should not contain `nodePort`.