### PR TITLE
[helm/chart] Improve charts

### DIFF
--- a/charts/gitlab-monitor/Chart.yaml
+++ b/charts/gitlab-monitor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: gitlab-monitor
-version: v0.1.0
+version: v0.2.0

--- a/charts/gitlab-monitor/templates/NOTES.txt
+++ b/charts/gitlab-monitor/templates/NOTES.txt
@@ -11,5 +11,5 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else }}
-  http://{{ .Release.Name }}.{{ .Values.basedomain }} to access your application
+  http://{{ .Values.ingress.domain }} to access your application
 {{- end }}

--- a/charts/gitlab-monitor/templates/ingress.yaml
+++ b/charts/gitlab-monitor/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   rules:
-  - host: {{ .Release.Name }}.{{ .Values.basedomain }}
+  - host: {{ .Values.ingress.domain }}
     http:
       paths:
       - path: /

--- a/charts/gitlab-monitor/templates/ingress.yaml
+++ b/charts/gitlab-monitor/templates/ingress.yaml
@@ -14,4 +14,8 @@ spec:
         backend:
           serviceName: {{ template "fullname" . }}
           servicePort: {{ .Values.service.externalPort }}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+{{- end }}
 {{- end -}}

--- a/charts/gitlab-monitor/templates/service.yaml
+++ b/charts/gitlab-monitor/templates/service.yaml
@@ -9,7 +9,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+{{- if eq .Values.service.type "LoadBalancer"}}
     nodePort: {{ .Values.service.nodePort }}
+{{- end}}
     protocol: TCP
     name: {{ .Values.service.name }}
   selector:

--- a/charts/gitlab-monitor/values.yaml
+++ b/charts/gitlab-monitor/values.yaml
@@ -22,6 +22,7 @@ resources:
 ingress:
   enabled: false
   domain: gitlab-monitor.example.com
+  tls: {}
 config: |
   {
     "gitlabApi": "https://gitlab.example.com/api/v4",

--- a/charts/gitlab-monitor/values.yaml
+++ b/charts/gitlab-monitor/values.yaml
@@ -21,7 +21,7 @@ resources:
     memory: 128Mi
 ingress:
   enabled: false
-basedomain: gitlab-monitor.example.com
+  domain: gitlab-monitor.example.com
 config: |
   {
     "gitlabApi": "https://gitlab.example.com/api/v4",


### PR DESCRIPTION
This PR improve gitlab-monitor's helm/charts :

- Handle `ClusterIP` service type
- Allow to specify full ingress domain
- Allow to specify tls parameter on ingress

Feel free to propose other improvements