### PR TITLE
Allow to trigger and play manual jobs directly from the dashboard

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -31,6 +31,9 @@ autoZoom: false
 # Whether to show pipeline IDs or not
 showPipelineIds: true
 
+# If true, manual jobs can be triggered from the project's card
+playJobs: false
+
 # Control how to show job names and icons
 # Can be: 'icon', 'name', 'iconAndName'
 showJobs: icon

--- a/src/GitLabApi.js
+++ b/src/GitLabApi.js
@@ -25,6 +25,12 @@ GitLabApi.install = (Vue, options) => {
       }
     }
     return result
+  },
+  Vue.prototype.$apiPost = async (path, params = {}) => {
+    const response = await axios.post(path, params, {
+      baseURL: Config.root.gitlabApi,   
+      headers: { 'Private-Token': Config.root.privateToken }
+    })
   }
 }
 

--- a/src/config.default.json
+++ b/src/config.default.json
@@ -7,6 +7,7 @@
   "autoZoom": false,
   "showPipelineIds": true,
   "showJobs": "icon",
+  "playJobs": false,
   "showJobsNameOnlyOn": [],
   "showRestartedJobs": true,
   "showStagesNames": false,

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ const finish = () => {
 // Load bundled config, if present.
 ;(async () => {
   try {
-    const {data} = await axios.get('/config.json')
+    const {data} = await axios.get('./config.json')
     Config.load(data)
   } catch (e) {
     Config.load()


### PR DESCRIPTION
i added a new configuration key "playsJobs" in the config file.
when set to true, any manual job can be triggered from the dashboard without jumping to the job's page in gitlab.