### PR TITLE
Fix filtering by project tags

### DIFF
--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -152,7 +152,7 @@
                     project.tag_list.length > 0 ||
                     !Config.root.filter.excludeUntagged
                   ) && (
-                    project.tag_list.length === 0 ||
+                    !Config.root.filter.includeTags) ||
                     project.tag_list.some(tag => tag.match(new RegExp(Config.root.filter.includeTags)))
                   )
                 )


### PR DESCRIPTION
The previous logic selects all projects without tags even if an includeTags-filter is defined. If no tags are defined, the project should not be selected if a filter is defined.