### PR TITLE
Support making a spoken announcement when pipelines fail

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -125,12 +125,21 @@ projectConfig:
     hideSkippedPipelines: false
 
     soundAlerts:
-      # If set to a non-null value, sound alerts will be enabled.
+      # If either soundUrl or speechTemplate is set to a non-null value, sound alerts will be enabled.
+      # speechTemplate takes precedence over soundUrl if both are set.
+
       # Replace null with URL to sound file.
       # IMPORTANT: Due to some browsers blocking autoplaying audio
       #            you may have to enable audio autoplay first!
       #  Firefox:  https://support.mozilla.org/en-US/kb/block-autoplay
       soundUrl: null
+
+      # Uses the SpeechSynthesis API to speak a message when a pipeline fails.
+      # Supports replacing the string NAME with the name of the user who triggered a pipeline.
+      # Replace null with a string like 'A pipeline triggered by NAME failed!'.
+      # You might have to enable auto autoplay or interact with the page at least once first.
+      # Not compatible with all browsers! See https://caniuse.com/#feat=mdn-api_speechsynthesis
+      speechTemplate: null
 
       # Play alert sounds for all branches matching this regex
       include: .*

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -136,7 +136,7 @@ projectConfig:
 
       # Uses the SpeechSynthesis API to speak a message when a pipeline fails.
       # Supports replacing the string NAME with the name of the user who triggered a pipeline.
-      # Replace null with a string like 'A pipeline triggered by NAME failed!'.
+      # Replace null with a string like 'NAME broke the build!'.
       # You might have to enable auto autoplay or interact with the page at least once first.
       # Not compatible with all browsers! See https://caniuse.com/#feat=mdn-api_speechsynthesis
       speechTemplate: null

--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -128,7 +128,8 @@
           }
 
           // Process alert sounds
-          const soundAlertsEnabled = (this.config.soundAlerts.soundUrl !== null || this.config.soundAlerts.speechTemplate !== null)
+          const spokenAlertsEnabled = window.speechSynthesis && this.config.soundAlerts.speechTemplate !== null
+          const soundAlertsEnabled = spokenAlertsEnabled || this.config.soundAlerts.soundUrl !== null
           if (pipelines && this.project && soundAlertsEnabled) {
             const pipelinesWithSoundAlertsEnabled = Object.keys(pipelines).filter(branchName => {
               return !!branchName.match(new RegExp(this.config.soundAlerts.include)) &&
@@ -145,7 +146,7 @@
             }
 
             if (newFailedPipelines.length > 0) {
-              if (this.config.soundAlerts.speechTemplate !== null && window.speechSynthesis) {
+              if (spokenAlertsEnabled) {
                 const template = this.config.soundAlerts.speechTemplate;
                 for (const pipeline of newFailedPipelines) {
                   const message = template.replace('NAME', pipeline.user.name)


### PR DESCRIPTION
I did this kind of as a joke, but this PR adds support for using the [SpeechSynthesis API](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis) to sound out a spoken message when pipelines fail.

The name of the user who triggered the pipeline can be included in the spoken message to call them out directly.

The SpeechSynthesis API is has been supported for a while on desktop Firefox, Chrome, Safari and Opera and also in the latest Edge release (https://caniuse.com/#feat=mdn-api_speechsynthesis).

Thanks for the work on this project, love the amount of detail the dashboard makes available!