### PR TITLE
Move logo in README.md to title and make it smaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# GitLab Monitor
-
-![Logo](/logo.svg)
+<h1> <img src="./logo.svg" alt="An abstract representation of an eye" width="24" height="24" /> GitLab Monitor</h1>
 
 > A browser-based monitor dashboard for GitLab CI
 


### PR DESCRIPTION
Will make the logo a tad more subtle.

Had to use html `<h1>` to make Github properly render the image inside the title. Also the space before 
the image is apparently necessary :shrug:

![image](https://user-images.githubusercontent.com/44374653/91459859-733fa000-e887-11ea-9e18-1a3fd201f56d.png)
