### PR TITLE
Added coverage to the pipeline view

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -73,6 +73,9 @@ showDurations: true
 # Whether to show the user that invoked the pipeline or not
 showUsers: false
 
+# Wether to show the pipelines test coverage if available
+showCoverage: false
+
 # The page title, or null to hide
 title: null
 

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -102,7 +102,7 @@
         timeString += secs
 
         return timeString
-      }
+      },
     },
     mounted() {
       this.fetchJobs()

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -115,7 +115,7 @@
       },
       'pipeline.status'() {
         this.$nextTick(() => this.setupDurationCounter())
-      }
+      },
     },
     methods: {
       async fetchJobs() {
@@ -180,13 +180,11 @@
               this.duration++
             }, 1000)
           }
-        } else {
-          if (this.durationCounterIntervalId) {
-            clearInterval(this.durationCounterIntervalId)
-            this.durationCounterIntervalId = null
-          }
+        } else if (this.durationCounterIntervalId) {
+          clearInterval(this.durationCounterIntervalId)
+          this.durationCounterIntervalId = null
         }
-      }
+      },
     }
   }
 </script>

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -33,6 +33,8 @@
         </div>
         <gitlab-icon v-if="showDurations && duration !== null" class="clock-icon" name="clock" size="10" />
         <span v-if="showDurations && duration !== null" class="duration">{{ durationString }}</span>
+        <gitlab-icon v-if="showCoverage && pipeline.coverage !== null" class="chart-icon" name="chart" size="10" />
+        <span v-if="showCoverage && pipeline.coverage !== null" class="coverage">{{ pipeline.coverage + '%' }}</span>
         <gitlab-icon v-if="showUsers && duration !== null" class="user-icon" name="user" size="10" />
         <span v-if="showUsers && pipeline.user !== null" class="user">{{ pipeline.user.name }}</span>
       </div>
@@ -74,6 +76,9 @@
             this.pipeline.status === 'success'
           )
       },
+      showCoverage() {
+        return Config.root.showCoverage
+      },
       showUsers() {
         return Config.root.showUsers
       },
@@ -97,7 +102,7 @@
         timeString += secs
 
         return timeString
-      },
+      }
     },
     mounted() {
       this.fetchJobs()
@@ -264,6 +269,18 @@
         color: var(--pipeline-user, rgba(255, 255, 255, 0.8));
         line-height: 1;
         font-size: 12px;
+      }
+
+      .coverage {
+        color: var(--pipeline-duration, rgba(255, 255, 255, 0.8));
+        line-height: 1;
+        font-size: 14px;
+        margin-right: 6px;
+      }
+
+      .chart-icon {
+        margin-right: 3px;
+        color: var(--pipeline-chart-icon, rgba(255, 255, 255, 0.5));
       }
 
       .skipped {

--- a/src/config.default.json
+++ b/src/config.default.json
@@ -12,6 +12,7 @@
   "showRestartedJobs": true,
   "showStagesNames": false,
   "showDurations": true,
+  "showCoverage": false,
   "showUsers": false,
   "projectVisibility": "any",
   "title": null,


### PR DESCRIPTION
My team needed a way to display the test coverage of the pipelines so i implemented it into the dashboard.
![Bildschirmfoto vom 2020-12-14 12-04-35](https://user-images.githubusercontent.com/3768372/102074453-1bf91780-3e05-11eb-815e-a5786e950a89.png)

The coverage is only displayed if there is data available. The coverage can be controlled ba the `showCoverage` setting and is disabled by default.

I'm not completly happy with the way that the data is displayed so input is very welcome.
 