### PR TITLE
Add test-report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules/
 dist/
+public/config.json
 npm-debug.log
 yarn-error.log
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -76,6 +76,9 @@ showUsers: false
 # Wether to show the pipelines test coverage if available
 showCoverage: false
 
+# Wether to show the pipelines test report if available
+showTestReport: true
+
 # The page title, or null to hide
 title: null
 

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -19,7 +19,7 @@
           class="pipeline-id-link"
           target="_blank"
           rel="noopener noreferrer"
-          :href="project.web_url + '/pipelines/' + pipeline.id"
+          :href="pipeline.web_url"
         >
           <gitlab-icon v-if="showPipelineIds" class="pipeline-icon" name="hashtag" size="12" />
           <div v-if="showPipelineIds" class="pipeline-id">{{ pipeline.id }}</div>
@@ -38,14 +38,8 @@
         <gitlab-icon v-if="showUsers && duration !== null" class="user-icon" name="user" size="10" />
         <span v-if="showUsers && pipeline.user !== null" class="user">{{ pipeline.user.name }}</span>
       </div>
-      <div v-if="showTestReport && pipeline.test_report !== null" class="pipeline test-report">
-        <span class="test-summary">Total ({{ pipeline.test_report.total_count }})</span>
-        <span class="test-summary">Sucess ({{ pipeline.test_report.success_count }})</span>
-        <span class="test-summary">Failed ({{ pipeline.test_report.failed_count }})</span>
-        <span class="test-summary">Skipped ({{ pipeline.test_report.skipped_count }})</span>
-        <span class="test-summary">Error ({{ pipeline.test_report.error_count }})</span>
-      </div>
     </div>
+    <test-report :pipeline="pipeline" />
   </div>
 </template>
 
@@ -55,12 +49,14 @@
   import Config from '../Config'
   import GitlabIcon from './gitlab-icon'
   import StageView from './stage-view'
+  import TestReport from './test-report'
 
   export default {
     components: {
       GitlabIcon,
       Octicon,
-      StageView
+      StageView,
+      TestReport
     },
     name: 'pipeline-view',
     props: ['pipeline', 'project', 'showBranch'],
@@ -131,7 +127,7 @@
       async fetchJobs() {
         this.jobs = await this.$api(`/projects/${this.project.id}/pipelines/${this.pipeline.id}/jobs?per_page=50`)
         this.jobs.sort((j1, j2) => j1.id - j2.id);
-        
+
         if (!Config.root.showRestartedJobs) {
           this.excludeRestartedJobs();
         }
@@ -227,6 +223,7 @@
       align-items: center;
       color: white;
       height: 30px;
+      margin-bottom: 4px;
 
       &.with-stages-names {
         padding-bottom: 20px;
@@ -254,19 +251,6 @@
         white-space: nowrap;
         margin-right: 8px;
         align-self: start;
-      }
-
-      .test-report {
-        white-space: nowrap;
-        margin-right: 8px;
-        align-self: start;
-      }
-
-      .test-summary {
-        color: var(--pipeline-duration, rgba(255, 255, 255, 0.5));
-        line-height: 1;
-        font-size: 12px;
-        margin-right: 12px;
       }
 
       .clock-icon {

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -38,6 +38,13 @@
         <gitlab-icon v-if="showUsers && duration !== null" class="user-icon" name="user" size="10" />
         <span v-if="showUsers && pipeline.user !== null" class="user">{{ pipeline.user.name }}</span>
       </div>
+      <div v-if="showTestReport && pipeline.test_report !== null" class="pipeline test-report">
+        <span class="test-summary">Total ({{ pipeline.test_report.total_count }})</span>
+        <span class="test-summary">Sucess ({{ pipeline.test_report.success_count }})</span>
+        <span class="test-summary">Failed ({{ pipeline.test_report.failed_count }})</span>
+        <span class="test-summary">Skipped ({{ pipeline.test_report.skipped_count }})</span>
+        <span class="test-summary">Error ({{ pipeline.test_report.error_count }})</span>
+      </div>
     </div>
   </div>
 </template>
@@ -85,6 +92,9 @@
       showStagesNames() {
         return Config.root.showStagesNames;
       },
+      showTestReport() {
+        return Config.root.showTestReport
+      },
       durationString() {
         const duration = this.duration
         const hrs = ~~(duration / 3600)
@@ -121,7 +131,7 @@
       async fetchJobs() {
         this.jobs = await this.$api(`/projects/${this.project.id}/pipelines/${this.pipeline.id}/jobs?per_page=50`)
         this.jobs.sort((j1, j2) => j1.id - j2.id);
-
+        
         if (!Config.root.showRestartedJobs) {
           this.excludeRestartedJobs();
         }
@@ -244,6 +254,19 @@
         white-space: nowrap;
         margin-right: 8px;
         align-self: start;
+      }
+
+      .test-report {
+        white-space: nowrap;
+        margin-right: 8px;
+        align-self: start;
+      }
+
+      .test-summary {
+        color: var(--pipeline-duration, rgba(255, 255, 255, 0.5));
+        line-height: 1;
+        font-size: 12px;
+        margin-right: 12px;
       }
 
       .clock-icon {

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -39,7 +39,7 @@
         <span v-if="showUsers && pipeline.user !== null" class="user">{{ pipeline.user.name }}</span>
       </div>
     </div>
-    <test-report :pipeline="pipeline" />
+    <test-report v-if="showTestReport && pipeline.test_report !== null" :pipeline="pipeline" />
   </div>
 </template>
 

--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -193,6 +193,7 @@
         this.loading = true
 
         const maxAge = Config.root.maxAge
+        const showTestReport = Config.root.showTestReport
         const showMerged = this.showMerged
         const showTags = this.showTags
         const fetchCount = Config.root.fetchCount
@@ -280,6 +281,11 @@
                   resolvedPipeline.status !== 'skipped'
                 )
               ) {
+                resolvedPipeline['test_report'] = null
+                if (showTestReport) {
+                  const testReport = await this.$api(`/projects/${this.projectId}/pipelines/${pipelines[i].id}/test_report`)
+                  resolvedPipeline['test_report'] = testReport
+                }
                 newPipelines[refName].push(resolvedPipeline)
                 count++
 

--- a/src/components/test-report.vue
+++ b/src/components/test-report.vue
@@ -1,31 +1,28 @@
 <template>
-  <div v-if="showTestReport && pipeline.test_report !== null">
-    <div class="test-report">
-        <a
-            class="pipeline-id-link"
-            target="_blank"
-            rel="noopener noreferrer"
-            :href="pipeline.web_url + '/test_report'"
-        >
-          <span class="test-summary">Test Report:</span>
-          <gitlab-icon class="test-icon" name="monitor" size="12" />
-          <span class="test-summary">{{ pipeline.test_report.total_count }}</span>
-          <gitlab-icon v-if="pipeline.test_report.success_count > 0" class="test-icon" name="status-success" size="12" />
-          <span v-if="pipeline.test_report.success_count > 0" class="test-summary">{{ pipeline.test_report.success_count }}</span>
-          <gitlab-icon v-if="pipeline.test_report.failed_count > 0" class="test-icon" name="status-failed" size="12" />
-          <span v-if="pipeline.test_report.failed_count > 0" class="test-summary">{{ pipeline.test_report.failed_count }}</span>
-          <gitlab-icon v-if="pipeline.test_report.skipped_count > 0" class="test-icon" name="status_skipped_borderless" size="12" />
-          <span v-if="pipeline.test_report.skipped_count > 0" class="test-summary">{{ pipeline.test_report.skipped_count }}</span>
-          <gitlab-icon v-if="pipeline.test_report.error_count > 0" class="test-icon" name="error" size="12" />
-          <span v-if="pipeline.test_report.error_count > 0" class="test-summary">{{ pipeline.test_report.error_count }}</span>
-        </a>
-    </div>
+  <div class="test-report">
+      <a
+          class="pipeline-id-link"
+          target="_blank"
+          rel="noopener noreferrer"
+          :href="pipeline.web_url + '/test_report'"
+      >
+        <span class="test-summary">Test Report:</span>
+        <gitlab-icon class="test-icon" name="monitor" size="12" />
+        <span class="test-summary">{{ pipeline.test_report.total_count }}</span>
+        <gitlab-icon v-if="pipeline.test_report.success_count > 0" class="test-icon" name="status-success" size="12" />
+        <span v-if="pipeline.test_report.success_count > 0" class="test-summary">{{ pipeline.test_report.success_count }}</span>
+        <gitlab-icon v-if="pipeline.test_report.failed_count > 0" class="test-icon" name="status-failed" size="12" />
+        <span v-if="pipeline.test_report.failed_count > 0" class="test-summary">{{ pipeline.test_report.failed_count }}</span>
+        <gitlab-icon v-if="pipeline.test_report.skipped_count > 0" class="test-icon" name="status_skipped_borderless" size="12" />
+        <span v-if="pipeline.test_report.skipped_count > 0" class="test-summary">{{ pipeline.test_report.skipped_count }}</span>
+        <gitlab-icon v-if="pipeline.test_report.error_count > 0" class="test-icon" name="error" size="12" />
+        <span v-if="pipeline.test_report.error_count > 0" class="test-summary">{{ pipeline.test_report.error_count }}</span>
+      </a>
   </div>
 </template>
 
 
 <script>
-import Config from '../Config'
 import GitlabIcon from './gitlab-icon'
 
 export default {
@@ -33,12 +30,7 @@ export default {
       GitlabIcon
     },
     name: 'test-report',
-    props: ['pipeline'],
-    computed: {
-        showTestReport() {
-            return Config.root.showTestReport
-        },  
-    }
+    props: ['pipeline']
 };
 </script>
 

--- a/src/components/test-report.vue
+++ b/src/components/test-report.vue
@@ -1,0 +1,56 @@
+<template>
+  <div v-if="showTestReport && pipeline.test_report !== null">
+    <div class="test-report">
+        <a
+            class="pipeline-id-link"
+            target="_blank"
+            rel="noopener noreferrer"
+            :href="pipeline.web_url + '/test_report'"
+        >
+          <span class="test-summary">Total ({{ pipeline.test_report.total_count }})</span>
+          <span class="test-summary">Sucess ({{ pipeline.test_report.success_count }})</span>
+          <span class="test-summary">Failed ({{ pipeline.test_report.failed_count }})</span>
+          <span class="test-summary">Skipped ({{ pipeline.test_report.skipped_count }})</span>
+          <span class="test-summary">Error ({{ pipeline.test_report.error_count }})</span>
+        </a>
+    </div>
+  </div>
+</template>
+
+
+<script>
+import Config from '../Config'
+
+export default {
+    name: 'test-report',
+    props: ['pipeline'],
+    computed: {
+        showTestReport() {
+            return Config.root.showTestReport
+        },  
+    }
+};
+</script>
+
+<style lang="scss" scoped>
+    .test-report {
+      padding: 1px;
+      border-top: 1px solid rgba(255, 255, 255, 0.1);
+      display: flex;
+      align-items: center;
+      color: white;
+      height: 30px;
+      
+      a {
+        text-decoration: none;
+      }
+
+      .test-summary {
+        color: var(--pipeline-duration, rgba(255, 255, 255, 0.5));
+        line-height: 1;
+        margin-right: 3px;
+        font-size: 12px;
+      }
+
+    }
+</style>

--- a/src/components/test-report.vue
+++ b/src/components/test-report.vue
@@ -7,11 +7,17 @@
             rel="noopener noreferrer"
             :href="pipeline.web_url + '/test_report'"
         >
-          <span class="test-summary">Total ({{ pipeline.test_report.total_count }})</span>
-          <span class="test-summary">Sucess ({{ pipeline.test_report.success_count }})</span>
-          <span class="test-summary">Failed ({{ pipeline.test_report.failed_count }})</span>
-          <span class="test-summary">Skipped ({{ pipeline.test_report.skipped_count }})</span>
-          <span class="test-summary">Error ({{ pipeline.test_report.error_count }})</span>
+          <span class="test-summary">Test Report:</span>
+          <gitlab-icon class="test-icon" name="monitor" size="12" />
+          <span class="test-summary">{{ pipeline.test_report.total_count }}</span>
+          <gitlab-icon v-if="pipeline.test_report.success_count > 0" class="test-icon" name="status-success" size="12" />
+          <span v-if="pipeline.test_report.success_count > 0" class="test-summary">{{ pipeline.test_report.success_count }}</span>
+          <gitlab-icon v-if="pipeline.test_report.failed_count > 0" class="test-icon" name="status-failed" size="12" />
+          <span v-if="pipeline.test_report.failed_count > 0" class="test-summary">{{ pipeline.test_report.failed_count }}</span>
+          <gitlab-icon v-if="pipeline.test_report.skipped_count > 0" class="test-icon" name="status_skipped_borderless" size="12" />
+          <span v-if="pipeline.test_report.skipped_count > 0" class="test-summary">{{ pipeline.test_report.skipped_count }}</span>
+          <gitlab-icon v-if="pipeline.test_report.error_count > 0" class="test-icon" name="error" size="12" />
+          <span v-if="pipeline.test_report.error_count > 0" class="test-summary">{{ pipeline.test_report.error_count }}</span>
         </a>
     </div>
   </div>
@@ -20,8 +26,12 @@
 
 <script>
 import Config from '../Config'
+import GitlabIcon from './gitlab-icon'
 
 export default {
+    components: {
+      GitlabIcon
+    },
     name: 'test-report',
     props: ['pipeline'],
     computed: {
@@ -35,7 +45,6 @@ export default {
 <style lang="scss" scoped>
     .test-report {
       padding: 1px;
-      border-top: 1px solid rgba(255, 255, 255, 0.1);
       display: flex;
       align-items: center;
       color: white;
@@ -43,6 +52,11 @@ export default {
       
       a {
         text-decoration: none;
+      }
+
+      .test-icon {
+        margin-right: 3px;
+        color: var(--pipeline-chart-icon, rgba(255, 255, 255, 0.5));
       }
 
       .test-summary {

--- a/src/config.default.json
+++ b/src/config.default.json
@@ -13,6 +13,7 @@
   "showStagesNames": false,
   "showDurations": true,
   "showCoverage": false,
+  "showTestReport": false,
   "showUsers": false,
   "projectVisibility": "any",
   "title": null,


### PR DESCRIPTION
As a QA, I'm also interested in the test report from a pipeline, and since my team Gitlab show it on a pretty page I also fetched it via the API.

Following a good example of another PR (https://github.com/timoschwarzer/gitlab-monitor/pull/162), I also added a proper flag for it (showTestReport) and made sure it will only show if there's data available.

I also wanted to add the suites/tests as an accordion below that summary, but couldn't make it pretty enough and maybe unnecessary (since one can just click on the summary and see details on Gitlab), but in any case, open for suggestions there.

![image](https://user-images.githubusercontent.com/380111/105987540-b3a58300-609e-11eb-9d08-d334dab1c9f5.png)
