### PR TITLE
Show detached pipelines

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -149,7 +149,10 @@ projectConfig:
     # Whether to show pipelines of tags
     showTags: true
 
-    # Minimum number of pipelines to display for this filter.
+    # Whether to show detached pipelines of merge requests
+    showDetached: false
+
+    # Minimum number of pipelines to display for this filter
     historyCount: 1
 
     # Hide skipped pipelines

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -158,6 +158,9 @@ projectConfig:
     # Hide skipped pipelines
     hideSkippedPipelines: false
 
+    # Hide successful pipelines
+    hideSuccessfulPipelines: false
+
     soundAlerts:
       # If set to a non-null value, sound alerts will be enabled.
       # Replace null with URL to sound file.

--- a/charts/gitlab-monitor/README.md
+++ b/charts/gitlab-monitor/README.md
@@ -14,7 +14,7 @@ $ git clone https://github.com/timoschwarzer/gitlab-monitor
 $ cd gitlab-monitor/charts/gitlab-monitor/
 ```
 Helm install monitor
-> note name and namespace can be customized. 
+> note name and namespace can be customized.
 ```bash
 $ helm install . -n gitlab-monitor --namespace default
 ```
@@ -53,6 +53,7 @@ config: |
         "default": null,
         "showMerged": false,
         "showTags": true,
+        "showDetached": false,
         "maxPipelines": 10,
         "notifyFailureOn": null
       }

--- a/charts/gitlab-monitor/values.yaml
+++ b/charts/gitlab-monitor/values.yaml
@@ -52,6 +52,7 @@ config: |
         "default": null,
         "showMerged": false,
         "showTags": true,
+        "showDetached": false,
         "maxPipelines": 10,
         "notifyFailureOn": null
       }

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -8,9 +8,9 @@
         class="branch"
         target="_blank"
         rel="noopener noreferrer"
-        :href="project.web_url + '/tree/' + pipeline.ref"
+        :href="project.web_url + (!pipeline.ref.includes('merge-request') ?  '/tree/' + pipeline.ref : '/-/merge_requests' + '/' + pipeline.ref.match(/\d+/))"
       >
-        <octicon name="git-branch" scale="0.9" />
+        <octicon :name="!pipeline.ref.includes('merge-request') ? 'git-branch' : 'git-pull-request'" scale="0.9" />
         {{ pipeline.ref }}
       </a>
 

--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -227,7 +227,7 @@
             per_page: fetchCount > 100 ? 100 : fetchCount
           }, { follow_next_page_links: fetchCount > 100 })
           for (const mergeRequest of mergeRequests) {
-            let mrPipelines = await this.$api(`/projects/${this.projectId}/merge_requests/${mergeRequest.iid}/pipelines`)
+            const mrPipelines = await this.$api(`/projects/${this.projectId}/merge_requests/${mergeRequest.iid}/pipelines`)
             if (mrPipelines.length > 0) {
               detached = detached.concat(mrPipelines[0].ref)
             }

--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -236,8 +236,8 @@
         const newPipelines = {}
         let count = 0
         const refNames = branchNames.concat(tagNames, detached)
-        let hideSkippedPipelines = Config.getProjectProperty('hideSkippedPipelines', this.project.path_with_namespace)
-        let hideSuccessfulPipelines = Config.getProjectProperty('hideSuccessfulPipelines', this.project.path_with_namespace)
+        const hideSkippedPipelines = Config.getProjectProperty('hideSkippedPipelines', this.project.path_with_namespace)
+        const hideSuccessfulPipelines = Config.getProjectProperty('hideSuccessfulPipelines', this.project.path_with_namespace)
 
         refLoop:
         for (const refName of refNames) {

--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -229,7 +229,7 @@
           for (const mergeRequest of mergeRequests) {
             const mrPipelines = await this.$api(`/projects/${this.projectId}/merge_requests/${mergeRequest.iid}/pipelines`)
             if (mrPipelines.length > 0) {
-              detached = detached.concat(mrPipelines[0].ref)
+              detached.push(mrPipelines[0].ref)
             }
           }
         }

--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -222,7 +222,7 @@
         const tagNames = tags.map((tag) => tag.name)
         let detached = []
         if (showDetached) {
-          let mergeRequests = await this.$api(`/projects/${this.projectId}/merge_requests`, {
+          const mergeRequests = await this.$api(`/projects/${this.projectId}/merge_requests`, {
             state: 'opened',
             per_page: fetchCount > 100 ? 100 : fetchCount
           }, { follow_next_page_links: fetchCount > 100 })

--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -237,6 +237,7 @@
         let count = 0
         const refNames = branchNames.concat(tagNames, detached)
         let hideSkippedPipelines = Config.getProjectProperty('hideSkippedPipelines', this.project.path_with_namespace)
+        let hideSuccessfulPipelines = Config.getProjectProperty('hideSuccessfulPipelines', this.project.path_with_namespace)
 
         refLoop:
         for (const refName of refNames) {
@@ -264,6 +265,9 @@
                 ) && (
                   !hideSkippedPipelines ||
                   resolvedPipeline.status !== 'skipped'
+                ) && (
+                  !hideSuccessfulPipelines ||
+                  resolvedPipeline.status !== 'success'
                 )
               ) {
                 resolvedPipelines.push(resolvedPipeline)
@@ -276,8 +280,12 @@
 
             for (const resolvedPipeline of resolvedPipelines) {
               if (
-                !hideSkippedPipelines ||
+                (!hideSkippedPipelines ||
                 resolvedPipeline.status !== 'skipped'
+                ) && (
+                !hideSuccessfulPipelines ||
+                resolvedPipeline.status !== 'success'
+                )
               ) {
                 newPipelines[refName].push(resolvedPipeline)
                 count++
@@ -296,6 +304,9 @@
                 ) && (
                   !hideSkippedPipelines ||
                   resolvedPipeline.status !== 'skipped'
+                ) && (
+                  !hideSuccessfulPipelines ||
+                  resolvedPipeline.status !== 'success'
                 )
               ) {
                 resolvedPipeline['test_report'] = null

--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -220,7 +220,7 @@
           }, { follow_next_page_links: fetchCount > 100 })
         }
         const tagNames = tags.map((tag) => tag.name)
-        let detached = []
+        const detached = []
         if (showDetached) {
           const mergeRequests = await this.$api(`/projects/${this.projectId}/merge_requests`, {
             state: 'opened',

--- a/src/config.default.json
+++ b/src/config.default.json
@@ -36,6 +36,7 @@
       "default": null,
       "showMerged": true,
       "showTags": true,
+      "showDetached": false,
       "historyCount": 1,
       "hideSkippedPipelines": false,
       "soundAlerts": {

--- a/src/config.default.json
+++ b/src/config.default.json
@@ -39,6 +39,7 @@
       "showDetached": false,
       "historyCount": 1,
       "hideSkippedPipelines": false,
+      "hideSuccessfulPipelines": false,
       "soundAlerts": {
         "soundUrl": null,
         "include": ".*",


### PR DESCRIPTION
Here is a try to to fix #165  and show detached pipelines as well.

This is achieved by
* an added project configuration `showDetached` (false per default to avoid changes for existing configurations)
* fetching a projects open merge requests (via https://docs.gitlab.com/ee/api/merge_requests.html#list-project-merge-requests)
* fetching the pipelines for these merge requests (via https://docs.gitlab.com/ee/api/merge_requests.html#list-mr-pipelines)
* adding those pipelines to the existing logic
* an updated icon and deep link in pipeline view

Additionally, a new configuration `hideSuccessfulPipelines` (false per default) to only show pipelines in non successful states  is added. Since `showProjectOnlyOn` only checks for the default branch, I feel like this is a nice additional feature to focus on errors.

What do you think?