### PR TITLE
Fixed error when historyCount is greater than number of pipelines

### DIFF
--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -296,7 +296,7 @@
               }
             }
 
-            for (let i = newPipelines[refName].length; i < historyCount; i++) {
+            for (let i = newPipelines[refName].length; (i < historyCount) && (i < pipelines.length); i++) {
               const resolvedPipeline = await this.$api(`/projects/${this.projectId}/pipelines/${pipelines[i].id}`)
               if (
                 (maxAge === 0 ||


### PR DESCRIPTION
When I tried to increase the `historyCount` to something greater than 1, the page wouldn't work anymore for me.

I started looking at the possible root cause, and I found this problem (`i` could become larger than `pipelines.length`).
Once resolved, the page would work again with the same configuration as before.