### PR TITLE
[FEAT] Added title of detached pipelines

### DIFF
--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -11,7 +11,7 @@
         :href="project.web_url + (!pipeline.ref.includes('merge-request') ?  '/tree/' + pipeline.ref : '/-/merge_requests' + '/' + pipeline.ref.match(/\d+/))"
       >
         <octicon :name="!pipeline.ref.includes('merge-request') ? 'git-branch' : 'git-pull-request'" scale="0.9" />
-        {{ pipeline.ref }}
+        {{ pipeline.ref }} <span v-if="pipeline.additional"> – {{ pipeline.additional.title }}</span>
       </a>
 
       <div :class="['pipeline', {'with-stages-names': showStagesNames, 'is-skipped': pipeline.status === 'skipped'}]">

--- a/src/components/project-card.vue
+++ b/src/components/project-card.vue
@@ -207,6 +207,8 @@
         const showDetached = this.showDetached
         const fetchCount = Config.root.fetchCount
 
+        let refNamesAdditional = {}
+
         const branches = await this.$api(`/projects/${this.projectId}/repository/branches`, {
           per_page: fetchCount > 100 ? 100 : fetchCount
         }, { follow_next_page_links: fetchCount > 100 })
@@ -238,7 +240,9 @@
           for (const mergeRequest of mergeRequests) {
             const mrPipelines = await this.$api(`/projects/${this.projectId}/merge_requests/${mergeRequest.iid}/pipelines`)
             if (mrPipelines.length > 0) {
-              detached.push(mrPipelines[0].ref)
+              const mrPipelineRef = mrPipelines[0].ref
+              detached.push(mrPipelineRef)
+              refNamesAdditional[mrPipelineRef] = {title: mergeRequest.title}
             }
           }
         }
@@ -296,6 +300,8 @@
                 resolvedPipeline.status !== 'success'
                 )
               ) {
+                resolvedPipeline.additional = refNamesAdditional[refName]
+
                 newPipelines[refName].push(resolvedPipeline)
                 count++
               }
@@ -323,6 +329,9 @@
                   const testReport = await this.$api(`/projects/${this.projectId}/pipelines/${pipelines[i].id}/test_report`)
                   resolvedPipeline['test_report'] = testReport
                 }
+
+                resolvedPipeline.additional = refNamesAdditional[refName]
+
                 newPipelines[refName].push(resolvedPipeline)
                 count++
 


### PR DESCRIPTION
In #166 I introduced the option to show detached pipelines. Unfortunately, it's hard to keep track of the detached pipelines since only their refName (like `refs/merge-requests/132/head`) is displayed. 

Therefore, I added `refNamesAdditional` (might be used for other features as well) and added the merge requests title to this new object. Since all data was already fetched, no additional requests were necessary. The title is displayed after the refName.