### PR TITLE
Include bridge jobs in pipeline (created using trigger)

### DIFF
--- a/src/components/job-view.vue
+++ b/src/components/job-view.vue
@@ -4,7 +4,7 @@
     target="_blank"
     :title="job.name"
     rel="noopener noreferrer"
-    :href="project.web_url + '/-/jobs/' + job.id"
+    :href="urlForJob"
   >
     <div :class="['job-circle', job.status === 'failed' ? (job.allow_failure ? 'warning' : 'failed') : job.status, {square: !showJobNames, hasIcon: showJobIcons}]">
       <transition name="fade" mode="out-in">
@@ -66,6 +66,14 @@
       },
       showJobIcons() {
         return Config.root.showJobs === 'icon' || Config.root.showJobs === 'iconAndName'
+      },
+      urlForJob() {
+        var isTriggerForAnotherPipeline = this.job.downstream_pipeline !== 'undefined' && this.job.downstream_pipeline != null
+        if (isTriggerForAnotherPipeline) {
+          return this.job.downstream_pipeline.web_url
+        } else {
+          return this.job.web_url
+        }
       }
     }
   }

--- a/src/components/job-view.vue
+++ b/src/components/job-view.vue
@@ -68,12 +68,9 @@
         return Config.root.showJobs === 'icon' || Config.root.showJobs === 'iconAndName'
       },
       urlForJob() {
-        var isTriggerForAnotherPipeline = this.job.downstream_pipeline !== 'undefined' && this.job.downstream_pipeline != null
-        if (isTriggerForAnotherPipeline) {
-          return this.job.downstream_pipeline.web_url
-        } else {
-          return this.job.web_url
-        }
+        return this.job.downstream_pipeline
+          ? this.job.downstream_pipeline.web_url
+          : this.job.web_url
       }
     }
   }

--- a/src/components/pipeline-view.vue
+++ b/src/components/pipeline-view.vue
@@ -125,7 +125,10 @@
     },
     methods: {
       async fetchJobs() {
-        this.jobs = await this.$api(`/projects/${this.project.id}/pipelines/${this.pipeline.id}/jobs?per_page=50`)
+        const coreJobs = await this.$api(`/projects/${this.project.id}/pipelines/${this.pipeline.id}/jobs?per_page=50`)
+        const bridgedJobs = await this.$api(`/projects/${this.project.id}/pipelines/${this.pipeline.id}/bridges?per_page=50`)
+
+        this.jobs = coreJobs.concat(bridgedJobs)
         this.jobs.sort((j1, j2) => j1.id - j2.id);
 
         if (!Config.root.showRestartedJobs) {


### PR DESCRIPTION
Gitlab allows a downstream pipeline to to be triggered as part
of any specific pipeline, by using the "trigger" keyword, see
https://docs.gitlab.com/ee/ci/yaml/#trigger

It looks like triggered pipelines are not included in the list
of jobs for a pipeline, but rather in a separate api,
GET /pipelines/xxx/bridges

This change checks for bridges in addition to jobs for a pipeline
and also ensures the link url from the ui targets the downstream
pipeline (this is different from a normal job url)

I'm a jvm developer with limited js experience so feel free to amend/improve/reject - I just thought I'd offer it seeing as I had written it, as I have pipelines that use "trigger:". 