### PR TITLE
Show GitLab runner status

### DIFF
--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -1,18 +1,23 @@
 <template>
   <div class="app">
-    <div v-if="loaded && configured" :style="{zoom}">
-      <h1 class="title" v-if="!!getTitle()">{{ getTitle() }}</h1>
-      <div class="projects">
-        <project-card
-          v-for="project in sortedProjects"
-          :key="project.id"
-          :project-id="project.id"
-        />
+    <template v-if="loaded && configured" :style="{zoom}">
+      <div class="content">
+        <h1 class="title" v-if="!!getTitle()">{{ getTitle() }}</h1>
+        <div class="projects">
+          <project-card
+            v-for="project in sortedProjects"
+            :key="project.id"
+            :project-id="project.id"
+          />
+        </div>
+        <div v-if="configured" class="configure" @click.prevent.stop="configured = false">
+          Configure
+        </div>
       </div>
-      <div>
+      <div v-if="showRunnerStatus()">
         <runner-status/>
       </div>
-    </div>
+    </template>
     <div v-else-if="!configured" class="container">
       <h1>Configuration</h1>
       <p>
@@ -43,16 +48,13 @@
     <div v-else class="loader">
       <octicon name="sync" spin scale="3" />
     </div>
-    <div v-if="configured" class="configure" @click.prevent.stop="configured = false">
-      Configure
-    </div>
   </div>
 </template>
 
 <script>
   import Octicon from 'vue-octicon/components/Octicon'
   import Config from '../Config'
-  import { configureApi } from '../GitLabApi'
+  import { configureApi } from '@/GitLabApi'
   import ProjectCard from './project-card'
   import RunnerStatus from './runner-status'
   import YAML from 'yaml'
@@ -119,7 +121,7 @@
         }
 
         return true
-      }
+      },
     },
     beforeMount() {
       this.reloadConfig()
@@ -315,6 +317,9 @@
       },
       getTitle() {
         return Config.root.title || null
+      },
+      showRunnerStatus() {
+        return Config.root.showRunnerStatus
       }
     }
   }
@@ -336,7 +341,7 @@
 
   body {
     margin: 0;
-    padding: 4px;
+    padding: 0;
     box-sizing: border-box;
     min-height: 100vh;
     background: url('../assets/backdrop.svg') no-repeat bottom;
@@ -368,6 +373,16 @@
 
 <style lang="scss" scoped>
   .app {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    flex-grow: 0;
+
+    .content {
+      flex-grow: 1;
+      overflow-y: auto;
+    }
+
     .title {
       text-align: center;
       margin-left: 8px;
@@ -394,8 +409,9 @@
     }
 
     .container {
-      padding: 0 16px;
       height: 100%;
+      overflow-y: auto;
+      padding: 0 16px 1em;
     }
 
     .config {
@@ -405,15 +421,14 @@
 
     .configure {
       position: fixed;
-      bottom: 22px;
       left: 0;
+      bottom: 0;
       padding: 16px 16px;
       background-color: #161616;
       border-top-right-radius: 3px;
       border-bottom-right-radius: 3px;
       border-top: 2px solid white;
       border-right: 2px solid white;
-      border-bottom: 2px solid white;
       opacity: 0;
       cursor: pointer;
 

--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -9,6 +9,9 @@
           :project-id="project.id"
         />
       </div>
+      <div>
+        <runner-status/>
+      </div>
     </div>
     <div v-else-if="!configured" class="container">
       <h1>Configuration</h1>
@@ -51,6 +54,7 @@
   import Config from '../Config'
   import { configureApi } from '../GitLabApi'
   import ProjectCard from './project-card'
+  import RunnerStatus from './runner-status'
   import YAML from 'yaml'
   import Visibilty from 'visibilityjs'
   import MonacoEditor from 'vue-monaco'
@@ -59,6 +63,7 @@
     components: {
       Octicon,
       ProjectCard,
+      RunnerStatus,
       MonacoEditor
     },
     name: 'app',
@@ -400,13 +405,15 @@
 
     .configure {
       position: fixed;
-      bottom: 0;
+      bottom: 22px;
       left: 0;
       padding: 16px 16px;
       background-color: #161616;
       border-top-right-radius: 3px;
+      border-bottom-right-radius: 3px;
       border-top: 2px solid white;
       border-right: 2px solid white;
+      border-bottom: 2px solid white;
       opacity: 0;
       cursor: pointer;
 

--- a/src/components/runner-status.vue
+++ b/src/components/runner-status.vue
@@ -1,0 +1,114 @@
+<template>
+  <div>
+    <div class="container" v-if="(runners_online.length + runners_active.length + runners_paused.length + runners_offline.length) > 0">
+      <span class="entry">Runner status:</span>
+      <span class="entry" v-if="runners_online.length > 0" :title="runners_online.join(', ')">
+        <div class="icon-online"/>
+        {{ runners_online.length }} online
+      </span>
+      <span class="entry" v-if="runners_active.length > 0" :title="runners_active.join(', ')">
+        <div class="icon-active"/>
+        {{ runners_active.length }} active
+      </span>
+      <span class="entry" v-if="runners_paused.length > 0" :title="runners_paused.join(', ')">
+        <div class="icon-paused"/>
+        {{ runners_paused.length}} paused
+      </span>
+      <span class="entry" v-if="runners_offline.length > 0" :title="runners_offline.join(', ')">
+        <div class="icon-offline"/>
+        {{ runners_offline.length}} offline
+      </span>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "runner-status",
+  props: [],
+  data: () => ({
+    runners_online: [],
+    runners_active: [],
+    runners_paused: [],
+    runners_offline: [],
+    refreshIntervalId: null
+  }),
+  computed: {},
+  mounted() {
+    this.fetchRunners()
+    this.setupRefreshInterval()
+  },
+  beforeDestroy() {
+    if (this.refreshIntervalId) {
+      clearInterval(this.refreshIntervalId)
+    }
+  },
+  methods: {
+    async fetchRunners() {
+      const runners = await this.$api('/runners')
+      this.runners_online = runners.filter(runner => runner.status === 'online').map(runner => runner.description)
+      this.runners_offline = runners.filter(runner => runner.status === 'offline').map(runner => runner.description)
+      this.runners_paused = runners.filter(runner => runner.status === 'paused').map(runner => runner.description)
+    },
+    setupRefreshInterval() {
+      if (this.refreshIntervalId) {
+        clearInterval((this.refreshIntervalId))
+      }
+      this.refreshIntervalId = setInterval(this.fetchRunners, 10000)
+    }
+  }
+
+}
+</script>
+
+<style lang="scss" scoped>
+.container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: var(--background-color, rgba(255,255,255,0.5));
+}
+
+.entry {
+  margin-left: 15px;
+  margin-right: 15px;
+}
+
+.icon-online {
+  display: inline-flex;
+  width: 10px;
+  height: 10px;
+  background-color: #2E7D32;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-radius: 999px;
+}
+
+.icon-active {
+  display: inline-flex;
+  width: 10px;
+  height: 10px;
+  background-color: #1565C0;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-radius: 999px;
+}
+
+.icon-paused {
+  display: inline-flex;
+  width: 10px;
+  height: 10px;
+  background-color: #EF6C00;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-radius: 999px;
+}
+
+.icon-offline {
+  display: inline-flex;
+  width: 10px;
+  height: 10px;
+  background-color: #C62828;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-radius: 999px;
+}
+
+</style>

--- a/src/components/runner-status.vue
+++ b/src/components/runner-status.vue
@@ -1,115 +1,117 @@
 <template>
   <div>
-    <div class="container" v-if="(runners_online.length + runners_active.length + runners_paused.length + runners_offline.length) > 0">
-      <span class="entry">Runner status:</span>
-      <span class="entry" v-if="runners_online.length > 0" :title="runners_online.join(', ')">
-        <div class="icon-online"/>
-        {{ runners_online.length }} online
-      </span>
-      <span class="entry" v-if="runners_active.length > 0" :title="runners_active.join(', ')">
-        <div class="icon-active"/>
-        {{ runners_active.length }} active
-      </span>
-      <span class="entry" v-if="runners_paused.length > 0" :title="runners_paused.join(', ')">
-        <div class="icon-paused"/>
-        {{ runners_paused.length}} paused
-      </span>
-      <span class="entry" v-if="runners_offline.length > 0" :title="runners_offline.join(', ')">
-        <div class="icon-offline"/>
-        {{ runners_offline.length}} offline
-      </span>
+    <div
+      class="container"
+      v-if="(runnersOnline.length + runnersActive.length + runnersPaused.length + runnersOffline.length) > 0"
+    >
+      <div class="entry">Runner status:</div>
+      <div class="entry" v-if="runnersOnline.length > 0" :title="runnersOnline.join(', ')">
+        <div class="icon icon-online"/>
+        {{ runnersOnline.length }} online
+      </div>
+      <div class="entry" v-if="runnersActive.length > 0" :title="runnersActive.join(', ')">
+        <div class="icon icon-active"/>
+        {{ runnersActive.length }} active
+      </div>
+      <div class="entry" v-if="runnersPaused.length > 0" :title="runnersPaused.join(', ')">
+        <div class="icon icon-paused"/>
+        {{ runnersPaused.length }} paused
+      </div>
+      <div class="entry" v-if="runnersOffline.length > 0" :title="runnersOffline.join(', ')">
+        <div class="icon icon-offline"/>
+        {{ runnersOffline.length }} offline
+      </div>
     </div>
   </div>
 </template>
 
 <script>
-export default {
-  name: "runner-status",
-  props: [],
-  data: () => ({
-    runners_online: [],
-    runners_active: [],
-    runners_paused: [],
-    runners_offline: [],
-    refreshIntervalId: null
-  }),
-  computed: {},
-  mounted() {
-    this.fetchRunners()
-    this.setupRefreshInterval()
-  },
-  beforeDestroy() {
-    if (this.refreshIntervalId) {
-      clearInterval(this.refreshIntervalId)
-    }
-  },
-  methods: {
-    async fetchRunners() {
-      const runners = await this.$api('/runners')
-      this.runners_online = runners.filter(runner => runner.status === 'online').map(runner => runner.description)
-      this.runners_active = runners.filter(runner => runner.status === 'active').map(runner => runner.description)
-      this.runners_offline = runners.filter(runner => runner.status === 'offline').map(runner => runner.description)
-      this.runners_paused = runners.filter(runner => runner.status === 'paused').map(runner => runner.description)
+  export default {
+    name: 'runner-status',
+    props: [],
+    data: () => ({
+      runnersOnline: [],
+      runnersActive: [],
+      runnersPaused: [],
+      runnersOffline: [],
+      refreshIntervalId: null,
+      fetchAllRunners: true,
+    }),
+    computed: {},
+    mounted() {
+      this.fetchRunners()
+      this.setupRefreshInterval()
     },
-    setupRefreshInterval() {
+    beforeDestroy() {
       if (this.refreshIntervalId) {
-        clearInterval((this.refreshIntervalId))
+        clearInterval(this.refreshIntervalId)
       }
-      this.refreshIntervalId = setInterval(this.fetchRunners, 10000)
+    },
+    methods: {
+      async fetchRunners() {
+        const runners = await this.$api('/runners')
+
+        try {
+          const allRunners = await this.$api('/runners/all')
+
+          for (const runner of allRunners) {
+            if (!runners.some(r => r.id === runner.id)) {
+              runners.push(runner)
+            }
+          }
+        } catch (e) {
+          this.fetchAllRunners = false
+          console.warn('Could not fetch all instance runners and won\'t try again.')
+        }
+
+        this.runnersOnline = runners.filter(runner => runner.status === 'online').map(runner => runner.description)
+        this.runnersActive = runners.filter(runner => runner.status === 'active').map(runner => runner.description)
+        this.runnersOffline = runners.filter(runner => runner.status === 'offline').map(runner => runner.description)
+        this.runnersPaused = runners.filter(runner => runner.status === 'paused').map(runner => runner.description)
+      },
+      setupRefreshInterval() {
+        if (this.refreshIntervalId) {
+          clearInterval((this.refreshIntervalId))
+        }
+        this.refreshIntervalId = setInterval(this.fetchRunners, 10000)
+      }
     }
   }
-
-}
 </script>
 
 <style lang="scss" scoped>
-.container {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  background-color: var(--background-color, rgba(255,255,255,0.5));
-}
+  .container {
+    background-color: var(--background-color, rgba(255, 255, 255, 0.5));
+    padding: 4px 8px;
+  }
 
-.entry {
-  margin-left: 15px;
-  margin-right: 15px;
-}
+  .entry {
+    display: inline-block;
+    margin-right: 1em;
+  }
 
-.icon-online {
-  display: inline-flex;
-  width: 10px;
-  height: 10px;
-  background-color: #2E7D32;
-  border: 2px solid rgba(0, 0, 0, 0.2);
-  border-radius: 999px;
-}
+  .icon {
+    display: inline-block;
+    width: 0.8em;
+    height: 0.8em;
+    transform: translateY(-10%);
+    vertical-align: middle;
+    border-radius: 50%;
 
-.icon-active {
-  display: inline-flex;
-  width: 10px;
-  height: 10px;
-  background-color: #1565C0;
-  border: 2px solid rgba(0, 0, 0, 0.2);
-  border-radius: 999px;
-}
+    &.icon-online {
+      background-color: var(--job-success, #2E7D32);
+    }
 
-.icon-paused {
-  display: inline-flex;
-  width: 10px;
-  height: 10px;
-  background-color: #EF6C00;
-  border: 2px solid rgba(0, 0, 0, 0.2);
-  border-radius: 999px;
-}
+    &.icon-active {
+      background-color: var(--job-running, #1565C0);
+    }
 
-.icon-offline {
-  display: inline-flex;
-  width: 10px;
-  height: 10px;
-  background-color: #C62828;
-  border: 2px solid rgba(0, 0, 0, 0.2);
-  border-radius: 999px;
-}
+    &.icon-paused {
+      background-color: var(--job-pending, #EF6C00);
+    }
 
+    &.icon-offline {
+      background-color: var(--job-failed, #C62828);
+    }
+  }
 </style>

--- a/src/components/runner-status.vue
+++ b/src/components/runner-status.vue
@@ -47,6 +47,7 @@ export default {
     async fetchRunners() {
       const runners = await this.$api('/runners')
       this.runners_online = runners.filter(runner => runner.status === 'online').map(runner => runner.description)
+      this.runners_active = runners.filter(runner => runner.status === 'active').map(runner => runner.description)
       this.runners_offline = runners.filter(runner => runner.status === 'offline').map(runner => runner.description)
       this.runners_paused = runners.filter(runner => runner.status === 'paused').map(runner => runner.description)
     },

--- a/src/config.default.json
+++ b/src/config.default.json
@@ -16,6 +16,7 @@
   "showCoverage": false,
   "showTestReport": false,
   "showUsers": false,
+  "showRunnerStatus": true,
   "projectVisibility": "any",
   "title": null,
   "orderBy": "lastActivity",


### PR DESCRIPTION
I implemented the feature requested in #161 .

Example output:
![normal](https://user-images.githubusercontent.com/2708365/128632245-c3b9abc2-ea5e-4f6a-96c9-41a6b5803011.png)

The name of the runners can be seen on hover:
![on_hover](https://user-images.githubusercontent.com/2708365/128632390-84e07d18-300f-4968-8291-29054aa556c0.png)

I moved the `Configure` button up so it wouldn't overlap:
![configure button](https://user-images.githubusercontent.com/2708365/128632446-8e95f0bd-7736-466f-8d79-1a2ce97457f2.png)

I didn't add a configuration option as I wasn't sure if it is needed, what are your thoughts on that ?